### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_ui_forms"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arboard",
  "async-channel",
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_ui_forms_form_proc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/macros/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/xenira/bevy_ui_forms"

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/Xenira/bevy_ui_forms/compare/bevy_ui_forms-v0.1.0...bevy_ui_forms-v0.2.0) - 2024-05-14
+
+### Added
+- *(button)* add button form element ([#11](https://github.com/Xenira/bevy_ui_forms/pull/11))
+
+### Other
+- *(deps)* Bump arboard from 3.3.2 to 3.4.0 ([#6](https://github.com/Xenira/bevy_ui_forms/pull/6))
+
 ## [0.1.0](https://github.com/Xenira/bevy_ui_forms/releases/tag/bevy_ui_forms-v0.1.0) - 2024-04-24
 
 ### Added

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -14,7 +14,7 @@ authors.workspace = true
 rust-version = "1.76.0"
 
 [dependencies]
-bevy_ui_forms_form_proc = { version = "0.1.0", optional = true, path = "../macros/form_proc" }
+bevy_ui_forms_form_proc = { version = "0.2.0", optional = true, path = "../macros/form_proc" }
 
 [dependencies.bevy]
 version = "0.13"

--- a/crates/macros/form_proc/CHANGELOG.md
+++ b/crates/macros/form_proc/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/Xenira/bevy_ui_forms/compare/bevy_ui_forms_form_proc-v0.1.0...bevy_ui_forms_form_proc-v0.2.0) - 2024-05-14
+
+### Added
+- *(button)* add button form element ([#11](https://github.com/Xenira/bevy_ui_forms/pull/11))
+
+### Other
+- *(deps)* Bump syn from 2.0.60 to 2.0.63 ([#10](https://github.com/Xenira/bevy_ui_forms/pull/10))
+
 ## [0.1.0](https://github.com/Xenira/bevy_ui_forms/releases/tag/bevy_ui_forms_form_proc-v0.1.0) - 2024-04-24
 
 ### Added


### PR DESCRIPTION
## 🤖 New release
* `bevy_ui_forms`: 0.1.0 -> 0.2.0 (⚠️ API breaking changes)
* `bevy_ui_forms_form_proc`: 0.1.0 -> 0.2.0

### ⚠️ `bevy_ui_forms` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/enum_variant_added.ron

Failed in:
  variant FormEvent:Apply in /tmp/.tmpVy7pGS/bevy_ui_forms/crates/core/src/form.rs:58
  variant FormEvent:Custom in /tmp/.tmpVy7pGS/bevy_ui_forms/crates/core/src/form.rs:62
  variant FormEvent:Apply in /tmp/.tmpVy7pGS/bevy_ui_forms/crates/core/src/form.rs:58
  variant FormEvent:Custom in /tmp/.tmpVy7pGS/bevy_ui_forms/crates/core/src/form.rs:62
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `bevy_ui_forms`
<blockquote>

## [0.2.0](https://github.com/Xenira/bevy_ui_forms/compare/bevy_ui_forms-v0.1.0...bevy_ui_forms-v0.2.0) - 2024-05-14

### Added
- *(button)* add button form element ([#11](https://github.com/Xenira/bevy_ui_forms/pull/11))

### Other
- *(deps)* Bump arboard from 3.3.2 to 3.4.0 ([#6](https://github.com/Xenira/bevy_ui_forms/pull/6))
</blockquote>

## `bevy_ui_forms_form_proc`
<blockquote>

## [0.2.0](https://github.com/Xenira/bevy_ui_forms/compare/bevy_ui_forms_form_proc-v0.1.0...bevy_ui_forms_form_proc-v0.2.0) - 2024-05-14

### Added
- *(button)* add button form element ([#11](https://github.com/Xenira/bevy_ui_forms/pull/11))

### Other
- *(deps)* Bump syn from 2.0.60 to 2.0.63 ([#10](https://github.com/Xenira/bevy_ui_forms/pull/10))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).